### PR TITLE
Prototype for range sliders 

### DIFF
--- a/application.py
+++ b/application.py
@@ -69,37 +69,6 @@ def graph(ch, sc):
                         value=[0, 7]
                     ),])
 
-# def display_graphs(jsonified_data) -> List:
-
-#     dff = pd.read_json(jsonified_data, orient='split')
-#     selected_charts = dff['sel_chrts'][0]
-#     selected_scenario = dff['sel_scenario'][0]
-
-#     plot_dict = plot_dicts[selected_scenario]
-#     graphs = []
-#     #if selectec_charts is not None:
-#     if isinstance(selected_charts, Iterable): 
-#         for value in selected_charts:
-#             print("adding" + value)
-#             curr_plt = plot_dict[value]
-
-#             graphs.append(dcc.Graph(id=value+'-fig')) #figure=plot_dict[value]))
-#             graphs.append(dcc.RangeSlider(
-#                                 id=value+'-slider',
-#                                 min=0,
-#                                 max=len(curr_plt['mid_plt_x']),
-#                                 step=None,
-#                                 marks={
-#                                     0: '0 days',
-#                                     7: '1 week',
-#                                     14: '2 weeks',
-#                                     40: '40 days'
-#                                 },
-#                                 value=[0, 7]
-#                             )
-#                         )
-#         return graphs
-
 @dash_app.callback(Output('Patients Presenting at Hospital-fig', 'figure'), 
                     [Input('Patients Presenting at Hospital-slider', 'value'),
                      Input('intermediate-value', 'children')])

--- a/application.py
+++ b/application.py
@@ -11,6 +11,9 @@ from components.charts import chart_panel
 from components.controls import control_panel
 from components.header import header_panel
 
+import pandas as pd 
+from collections.abc import Iterable
+
 dash_app = dash.Dash(__name__)
 dash_app.config.suppress_callback_exceptions = True
 application = dash_app.server
@@ -22,125 +25,182 @@ dash_app.layout = html.Div(
     className='container', children=[
         header_panel(),
         control_panel(plot_options, len(plot_dicts)),
-        chart_panel(),   
-    ]
+        #chart_panel(),  
+        html.Div(id='graphs'),
+        html.Div(id='intermediate-value', style={'display': 'none'}),
+    ],
 )
 
+@dash_app.callback(Output('intermediate-value', 'children'), 
+                            [Input('chart_selector', 'value'),
+                             Input('scenario_selector', 'value')])
+def save_data(selected_charts: List, selected_scenario: int):
+     s_c = selected_charts
+     s_s = selected_scenario
+     s_data = {'sel_chrts': [s_c], 'sel_scenario':[s_s]} 
+     state_data = pd.DataFrame(data=s_data)
+     return state_data.to_json(date_format='iso', orient='split')
 
-@dash_app.callback(Output('output', 'children'), [Input('chart_selector', 'value'),
-                                                  Input('scenario_selector', 'value')])
-def display_graphs(selected_charts: List, selected_scenario: int) -> List:
-    plot_dict = plot_dicts[selected_scenario]
-    graphs = []
-    if selected_charts is not None:
-        for value in selected_charts:
-            curr_plt = plot_dict[value]
+@dash_app.callback(Output('graphs', 'children'), 
+                        [Input('intermediate-value', 'children')])
+def graphs_selected(jsonified_data):
+    charts_to_show = get_charts(jsonified_data)
+    scenario_to_show = get_scenario(jsonified_data)
+    if isinstance(charts_to_show, Iterable): 
+        return html.Div([graph(chart, scenario_to_show) for chart in charts_to_show])
+    return 
 
-            graphs.append(dcc.Graph(id=value+'-fig')) #figure=plot_dict[value]))
-            graphs.append(dcc.RangeSlider(
-                                id=value+'-slider',
-                                min=0,
-                                max=len(curr_plt['mid_plt_x']),
-                                step=None,
-                                marks={
-                                    0: '0 days',
-                                    7: '1 week',
-                                    14: '2 weeks',
-                                    40: '40 days'
-                                },
-                                value=[0, 7]
-                            )
-                        )
-        return graphs
+def graph(ch, sc):
+    plot_dict = plot_dicts[sc]
+    curr_plt = plot_dict[ch]
+
+    return html.Div(id=ch, children=[
+        dcc.Graph(id=ch+'-fig', figure=update_graph(curr_plt, [0,7])),
+        dcc.RangeSlider(id=ch+'-slider',
+                        min=0,
+                        max=len(curr_plt['mid_plt_x']),
+                        step=None,
+                        marks={
+                            0: '0 days',
+                            7: '1 week',
+                            14: '2 weeks',
+                            40: '40 days'
+                        },
+                        value=[0, 7]
+                    ),])
+
+# def display_graphs(jsonified_data) -> List:
+
+#     dff = pd.read_json(jsonified_data, orient='split')
+#     selected_charts = dff['sel_chrts'][0]
+#     selected_scenario = dff['sel_scenario'][0]
+
+#     plot_dict = plot_dicts[selected_scenario]
+#     graphs = []
+#     #if selectec_charts is not None:
+#     if isinstance(selected_charts, Iterable): 
+#         for value in selected_charts:
+#             print("adding" + value)
+#             curr_plt = plot_dict[value]
+
+#             graphs.append(dcc.Graph(id=value+'-fig')) #figure=plot_dict[value]))
+#             graphs.append(dcc.RangeSlider(
+#                                 id=value+'-slider',
+#                                 min=0,
+#                                 max=len(curr_plt['mid_plt_x']),
+#                                 step=None,
+#                                 marks={
+#                                     0: '0 days',
+#                                     7: '1 week',
+#                                     14: '2 weeks',
+#                                     40: '40 days'
+#                                 },
+#                                 value=[0, 7]
+#                             )
+#                         )
+#         return graphs
 
 @dash_app.callback(Output('Patients Presenting at Hospital-fig', 'figure'), 
                     [Input('Patients Presenting at Hospital-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_presenting(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_presenting_at_hospital(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients Presenting at Hospital']
     return update_graph(p_df, selected_range)
 
 @dash_app.callback(Output('Patients in General Ward-fig', 'figure'), 
                     [Input('Patients in General Ward-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_gen(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_in_general_ward(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients in General Ward']
     return update_graph(p_df, selected_range)
 
 @dash_app.callback(Output('Patients in ICU (but not on Ventilator)-fig', 'figure'), 
                     [Input('Patients in ICU (but not on Ventilator)-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_no_vent_icu(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_in_icu_no_vent(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients in ICU (but not on Ventilator)']
     return update_graph(p_df, selected_range)
 
 @dash_app.callback(Output('Patients on Ventilator in ICU-fig', 'figure'), 
                     [Input('Patients on Ventilator in ICU-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_vent_icu(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_in_icu_on_vent(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients on Ventilator in ICU']
     return update_graph(p_df, selected_range)
 
 @dash_app.callback(Output('Patients that Die Each Day-fig', 'figure'), 
                     [Input('Patients that Die Each Day-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_die(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_die(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients that Die Each Day']
     return update_graph(p_df, selected_range)
 
 @dash_app.callback(Output('Patients Added to General Ward each day-fig', 'figure'), 
                     [Input('Patients Added to General Ward each day-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_added_gen(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_added_general_ward(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients Added to General Ward each day']
     return update_graph(p_df, selected_range)
 
 @dash_app.callback(Output('Patients Added to ICU (but not on vent) each day-fig', 'figure'), 
                     [Input('Patients Added to ICU (but not on vent) each day-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_added_no_vent_icu(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_added_icu_no_vent(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients Added to ICU (but not on vent) each day']
     return update_graph(p_df, selected_range)
 
 @dash_app.callback(Output('Patients Added on Ventilator in ICU each day-fig', 'figure'), 
                     [Input('Patients Added on Ventilator in ICU each day-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_added_vent_icu(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_added_icu_on_vent(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients Added on Ventilator in ICU each day']
     return update_graph(p_df, selected_range)
  
 @dash_app.callback(Output('Patients Discharged from General Ward each day-fig', 'figure'), 
                     [Input('Patients Discharged from General Ward each day-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_discharged_gen(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_discharged_general_ward(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients Discharged from General Ward each day']
     return update_graph(p_df, selected_range)
  
 @dash_app.callback(Output('Patients Discharged from ICU (but not on vent) each day-fig', 'figure'), 
                     [Input('Patients Discharged from ICU (but not on vent) each day-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_discharged_no_vent_icu(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_discharged_icu_no_vent(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients Discharged from ICU (but not on vent) each day']
     return update_graph(p_df, selected_range)
 
 @dash_app.callback(Output('Patients Discharged from On Ventilator In ICU each day-fig', 'figure'), 
-                    [Input('Patients Discharged from On Ventilator In ICU each dayl-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_discharged_vent_icu(selected_range, selected_scenario):
+                    [Input('Patients Discharged from On Ventilator In ICU each day-slider', 'value'),
+                     Input('intermediate-value', 'children')])
+def update_patients_discharged_icu_on_vent(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients Discharged from On Ventilator In ICU each day']
     return update_graph(p_df, selected_range)
 
 @dash_app.callback(Output('Patients discharged from Presenting each day (fully recovered)-fig', 'figure'), 
                     [Input('Patients discharged from Presenting each day (fully recovered)-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_discharged_presenting(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_discharged_presenting(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients discharged from Presenting each day (fully recovered)']
     return update_graph(p_df, selected_range)
 
 @dash_app.callback(Output('Patients added to Presenting each day-fig', 'figure'), 
                     [Input('Patients added to Presenting each day-slider', 'value'),
-                     Input('scenario_selector', 'value')])
-def update_patients_added_presenting(selected_range, selected_scenario):
+                     Input('intermediate-value', 'children')])
+def update_patients_added_presenting(selected_range, jsonified_data):
+    selected_scenario = get_scenario(jsonified_data)
     p_df = plot_dicts[selected_scenario]['Patients added to Presenting each day']
     return update_graph(p_df, selected_range)
 
@@ -195,6 +255,16 @@ def update_graph(plot_df, sel_range):
             yaxis_linecolor=plot_df['plt_yaxis_linecolor'],
         )
     }
+
+def get_scenario(j_data):
+    dff = pd.read_json(j_data, orient='split')
+    selected_scenario = dff['sel_scenario'][0]
+    return selected_scenario
+
+def get_charts(j_data):
+    dff = pd.read_json(j_data, orient='split')
+    selected_charts = dff['sel_chrts'][0] 
+    return selected_charts
 
 
 if __name__ == '__main__':

--- a/application.py
+++ b/application.py
@@ -12,6 +12,7 @@ from components.controls import control_panel
 from components.header import header_panel
 
 dash_app = dash.Dash(__name__)
+dash_app.config.suppress_callback_exceptions = True
 application = dash_app.server
 
 plot_dicts = plot.main()
@@ -21,7 +22,7 @@ dash_app.layout = html.Div(
     className='container', children=[
         header_panel(),
         control_panel(plot_options, len(plot_dicts)),
-        chart_panel()
+        chart_panel(),   
     ]
 )
 
@@ -33,8 +34,167 @@ def display_graphs(selected_charts: List, selected_scenario: int) -> List:
     graphs = []
     if selected_charts is not None:
         for value in selected_charts:
-            graphs.append(dcc.Graph(figure=plot_dict[value]))
+            curr_plt = plot_dict[value]
+
+            graphs.append(dcc.Graph(id=value+'-fig')) #figure=plot_dict[value]))
+            graphs.append(dcc.RangeSlider(
+                                id=value+'-slider',
+                                min=0,
+                                max=len(curr_plt['mid_plt_x']),
+                                step=None,
+                                marks={
+                                    0: '0 days',
+                                    7: '1 week',
+                                    14: '2 weeks',
+                                    40: '40 days'
+                                },
+                                value=[0, 7]
+                            )
+                        )
         return graphs
+
+@dash_app.callback(Output('Patients Presenting at Hospital-fig', 'figure'), 
+                    [Input('Patients Presenting at Hospital-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_presenting(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients Presenting at Hospital']
+    return update_graph(p_df, selected_range)
+
+@dash_app.callback(Output('Patients in General Ward-fig', 'figure'), 
+                    [Input('Patients in General Ward-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_gen(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients in General Ward']
+    return update_graph(p_df, selected_range)
+
+@dash_app.callback(Output('Patients in ICU (but not on Ventilator)-fig', 'figure'), 
+                    [Input('Patients in ICU (but not on Ventilator)-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_no_vent_icu(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients in ICU (but not on Ventilator)']
+    return update_graph(p_df, selected_range)
+
+@dash_app.callback(Output('Patients on Ventilator in ICU-fig', 'figure'), 
+                    [Input('Patients on Ventilator in ICU-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_vent_icu(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients on Ventilator in ICU']
+    return update_graph(p_df, selected_range)
+
+@dash_app.callback(Output('Patients that Die Each Day-fig', 'figure'), 
+                    [Input('Patients that Die Each Day-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_die(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients that Die Each Day']
+    return update_graph(p_df, selected_range)
+
+@dash_app.callback(Output('Patients Added to General Ward each day-fig', 'figure'), 
+                    [Input('Patients Added to General Ward each day-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_added_gen(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients Added to General Ward each day']
+    return update_graph(p_df, selected_range)
+
+@dash_app.callback(Output('Patients Added to ICU (but not on vent) each day-fig', 'figure'), 
+                    [Input('Patients Added to ICU (but not on vent) each day-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_added_no_vent_icu(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients Added to ICU (but not on vent) each day']
+    return update_graph(p_df, selected_range)
+
+@dash_app.callback(Output('Patients Added on Ventilator in ICU each day-fig', 'figure'), 
+                    [Input('Patients Added on Ventilator in ICU each day-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_added_vent_icu(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients Added on Ventilator in ICU each day']
+    return update_graph(p_df, selected_range)
+ 
+@dash_app.callback(Output('Patients Discharged from General Ward each day-fig', 'figure'), 
+                    [Input('Patients Discharged from General Ward each day-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_discharged_gen(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients Discharged from General Ward each day']
+    return update_graph(p_df, selected_range)
+ 
+@dash_app.callback(Output('Patients Discharged from ICU (but not on vent) each day-fig', 'figure'), 
+                    [Input('Patients Discharged from ICU (but not on vent) each day-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_discharged_no_vent_icu(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients Discharged from ICU (but not on vent) each day']
+    return update_graph(p_df, selected_range)
+
+@dash_app.callback(Output('Patients Discharged from On Ventilator In ICU each day-fig', 'figure'), 
+                    [Input('Patients Discharged from On Ventilator In ICU each dayl-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_discharged_vent_icu(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients Discharged from On Ventilator In ICU each day']
+    return update_graph(p_df, selected_range)
+
+@dash_app.callback(Output('Patients discharged from Presenting each day (fully recovered)-fig', 'figure'), 
+                    [Input('Patients discharged from Presenting each day (fully recovered)-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_discharged_presenting(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients discharged from Presenting each day (fully recovered)']
+    return update_graph(p_df, selected_range)
+
+@dash_app.callback(Output('Patients added to Presenting each day-fig', 'figure'), 
+                    [Input('Patients added to Presenting each day-slider', 'value'),
+                     Input('scenario_selector', 'value')])
+def update_patients_added_presenting(selected_range, selected_scenario):
+    p_df = plot_dicts[selected_scenario]['Patients added to Presenting each day']
+    return update_graph(p_df, selected_range)
+
+ 
+def update_graph(plot_df, sel_range): 
+    lower_x_filtered = plot_df['lower_plt_x'].iloc[sel_range[0]:sel_range[1]]
+    lower_y_filtered = plot_df['lower_plt_y'].iloc[sel_range[0]:sel_range[1]]
+    upper_x_filtered = plot_df['upper_plt_x'].iloc[sel_range[0]:sel_range[1]]
+    upper_y_filtered = plot_df['upper_plt_y'].iloc[sel_range[0]:sel_range[1]]
+    mid_x_filtered = plot_df['mid_plt_x'].iloc[sel_range[0]:sel_range[1]]
+    mid_y_filtered = plot_df['mid_plt_y'].iloc[sel_range[0]:sel_range[1]]
+    
+    traces = []
+    traces.append(dict(
+            x=lower_x_filtered,
+            y=lower_y_filtered,
+            fill=plot_df['lower_plt_fill'],
+            mode=plot_df['lower_plt_mode'],
+            line =plot_df['lower_plt_line'],
+            name=plot_df['lower_plt_name']
+        ))
+    traces.append(dict(
+            x=upper_x_filtered,
+            y=upper_y_filtered,
+            fill=plot_df['upper_plt_fill'],
+            fillcolor=plot_df['upper_plt_fillcolor'],
+            mode=plot_df['upper_plt_mode'],
+            line =plot_df['upper_plt_line'],
+            name=plot_df['upper_plt_name']
+        ))
+    traces.append(dict(
+            x=mid_x_filtered,
+            y=mid_y_filtered,
+            fill=plot_df['mid_plt_fill'],
+            fillcolor=plot_df['mid_plt_fillcolor'],
+            line =plot_df['mid_plt_line'],
+            name=plot_df['mid_plt_name']
+        ))
+                        
+    return {
+        'data': traces,
+        'layout': dict(
+            title=plot_df['plt_title'],
+            xaxis_tickformat=plot_df['plt_xaxis_tickformat'],
+            xaxis_tickangle=plot_df['plt_xaxis_tickangle'],
+            yaxis_title=plot_df['plt_yaxis_title'],
+            font=plot_df['plt_font'],
+            hovermode=plot_df['plt_hovermode'],
+            showlegend=plot_df['plt_showlegend'],
+            plot_bgcolor=plot_df['plt_plot_bgcolor'],
+            xaxis_linecolor=plot_df['plt_xaxis_linecolor'],
+            yaxis_linecolor=plot_df['plt_yaxis_linecolor'],
+        )
+    }
 
 
 if __name__ == '__main__':

--- a/application.py
+++ b/application.py
@@ -69,6 +69,37 @@ def graph(ch, sc):
                         value=[0, 7]
                     ),])
 
+# def display_graphs(jsonified_data) -> List:
+
+#     dff = pd.read_json(jsonified_data, orient='split')
+#     selected_charts = dff['sel_chrts'][0]
+#     selected_scenario = dff['sel_scenario'][0]
+
+#     plot_dict = plot_dicts[selected_scenario]
+#     graphs = []
+#     #if selectec_charts is not None:
+#     if isinstance(selected_charts, Iterable): 
+#         for value in selected_charts:
+#             print("adding" + value)
+#             curr_plt = plot_dict[value]
+
+#             graphs.append(dcc.Graph(id=value+'-fig')) #figure=plot_dict[value]))
+#             graphs.append(dcc.RangeSlider(
+#                                 id=value+'-slider',
+#                                 min=0,
+#                                 max=len(curr_plt['mid_plt_x']),
+#                                 step=None,
+#                                 marks={
+#                                     0: '0 days',
+#                                     7: '1 week',
+#                                     14: '2 weeks',
+#                                     40: '40 days'
+#                                 },
+#                                 value=[0, 7]
+#                             )
+#                         )
+#         return graphs
+
 @dash_app.callback(Output('Patients Presenting at Hospital-fig', 'figure'), 
                     [Input('Patients Presenting at Hospital-slider', 'value'),
                      Input('intermediate-value', 'children')])

--- a/config.json
+++ b/config.json
@@ -5,9 +5,6 @@
     "summary_upper_file": "summary-percentile=097.50.csv",
     "summary_lower_file": "summary-percentile=002.50.csv",
     "time_step_format": "%m/%d/%Y",
-    "comma_sep_scenario_titles": "",
-    "scenario_id": 0,
-    "scenario_title": "Scenario1",
     "first_time_step": "04/07/2020",
     "time_delta": "1d",
     "num_scenarios": 4

--- a/labels.json
+++ b/labels.json
@@ -1,15 +1,16 @@
 {
-    "n_InGeneralWard": "Patient Count in General Ward each day",
-    "n_OffVentInICU": "Patient Count in ICU (not on Ventilator) each day",
-    "n_OnVentInICU": "Patients Count on Ventilator in ICU each day",
-    "n_TERMINAL": "Patients that Die each day",
-    "n_admitted_Presenting": "Patients Presenting at Hospital each day",
+    "n_Presenting": "Patients Presenting at Hospital",
+    "n_InGeneralWard": "Patients in General Ward",
+    "n_InICU": "Patients in ICU (but not on Ventilator)",
+    "n_OnVentInICU": "Patients on Ventilator in ICU",
+    "n_TERMINAL": "Patients that Die Each Day",
     "n_admitted_InGeneralWard": "Patients Added to General Ward each day",
-    "n_admitted_OffVentInICU": "Patients Added to ICU (not on Vent) each day",
-    "n_admitted_OnVentInICU": "Patients Added on Ventilator in ICU each day",    
-    "n_discharged_Presenting": "Patients Discharged from Presenting each day (fully recovered)", 
-    "n_discharged_InGeneralWard": "Patients Discharged from General Ward each day (fully recovered)",
-    "n_discharged_OffVentInICU": "Patients Discharged from ICU (not on Vent) each day (fully recovered)",
-    "n_discharged_OnVentInICU": "Patients Discharged from Ventilator In ICU each day (fully recovered)"
+    "n_admitted_InICU": "Patients Added to ICU (but not on vent) each day",
+    "n_admitted_OnVentInICU": "Patients Added on Ventilator in ICU each day",
+    "n_discharged_InGeneralWard": "Patients Discharged from General Ward each day",
+    "n_discharged_InICU": "Patients Discharged from ICU (but not on vent) each day",
+    "n_discharged_OnVentInICU": "Patients Discharged from On Ventilator In ICU each day",
+    "n_discharged_Presenting": "Patients discharged from Presenting each day (fully recovered)", 
+    "n_admitted_Presenting": "Patients added to Presenting each day"
 }
 

--- a/plot.py
+++ b/plot.py
@@ -21,16 +21,13 @@ def load_output_data(config=None):
 
     summary_files = [(key, val) for (key, val) in config.items() if key.startswith('summary_')]
     all_scenario_dataframes = []
-    for scenario_number in range(0, int(num_scenarios)):
+    for scenario_number in range(0, num_scenarios):
         scenario_dataframes = []
         scenario_output_path = output_path + '_{}/'.format(scenario_number)
         for file_type, file_name in summary_files:
             percentile = re.findall('\d*\.?\d+', file_name)[0]
 
-            try:
-                df_temp = pd.read_csv(os.path.join(scenario_output_path, file_name))
-            except FileNotFoundError:
-                df_temp = pd.read_csv(os.path.join(output_path, file_name))
+            df_temp = pd.read_csv(os.path.join(scenario_output_path, file_name))
             df_temp['percentile'] = percentile
             df_temp['timestep_formatted'] = df_temp.apply(lambda x: fill_timestep(x.timestep, first_time_step_datetime, time_delta), axis=1)
 
@@ -244,59 +241,13 @@ def make_plot_dfs(dfs, labels, time_step_format):
 
 
 # TODO: Figure out why the graph object height is 100% of view window
-def figures_to_html(figs, labels, scenario_title, first_time_step, filename="dashboard.html"):
+def figures_to_html(figs, filename="dashboard.html"):
     dashboard = open(filename, 'w')
-    html = '''<html>
-           <head>
-           <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-           <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>        
-           <link rel='stylesheet' type='text/css' href='assets/style.css'>
-           </head>
-           <body>
-           <div class='container'>
-           <h2>COVID-19 Forecast for TMC (Experimental Draft)</h2>
-           <h1 class="text-center"> {scenario_title} </h1>
-           <div class="container-fluid text-left">
-           <div class="row content">
-           <p> Forecasts started on day: {first_time_step} </p>
-           <a name='resources'><h3>Resources</h3></a>
-                <ul>
-                    <li> Parameters: <a href="params.txt">params.txt</a> </li>
-                    <li> Mean CSV summary: <a href="summary-mean.csv">summary-mean.csv</a> </li>
-                    <li> Median CSV summary: <a href="summary-percentile=050.00.csv">summary-percentile=050.00.csv</a></li> 
-                    <li> 2.5th-perc. CSV summary: <a href="summary-percentile=002.50.csv">summary-percentile=002.50.csv</a></li> 
-                    <li> 97.5th-perc. CSV summary: <a href="summary-percentile=097.50.csv">summary-percentile=097.50.csv</a></li> 
-                </ul>
-           </div>
-           <div class="row content">
-           <a name='toc'><h3>Plots</h3></a>
-           <div class="col-md-12 text-left"> 
-           <table class="table" width="100%" border="1">
-        '''.format(scenario_title=scenario_title, first_time_step=first_time_step)
-
-    keys = list(labels.keys())
-    L = len(keys)
-    C = 3 # num cols
-    M = L // C # num rows
-    list_per_row = [keys[m::M] for m in range(M)]
-    key_order = sum(list_per_row, []) # concatenate into flat ordered list
-    is_first_col = lambda kk: (kk % C == 0)
-    is_last_col = lambda kk: (kk % C == (M-1))
-    for kk, key in enumerate(key_order):
-        if is_first_col(kk):
-            html += "\n<tr>"
-        html += '\n    <td class="col-md-4"><a href="#%s">%s</a></td>' % (key, labels[key])
-        if is_last_col(kk):
-            html += "\n</tr>"
-    html += "\n</table></div></div></div>"
-    dashboard.write(html + "\n\n")
-
-    inv_labels = dict(zip(labels.values(), labels.keys()))
-
+    dashboard.write("<html>"
+                    "<head><link rel='stylesheet' type='text/css' href='assets/style.css'></head>"
+                    "<body><div class='container'><h2>COVID-19 Forecast for TMC (Experimental Draft; Do Not Take Seriously)</h2>" + "\n")
     for k, v in figs.items():
         inner_html = v.to_html().split("<body>")[1].split("</body>")[0]
-        dashboard.write("<a name='%s'><h4>%s</h4>\n" % (inv_labels[k], k))
-        dashboard.write("<a href='#toc'>[back to top]</a>\n")
         dashboard.write(inner_html)
     dashboard.write("</div></body></html>" + "\n")
 
@@ -316,12 +267,7 @@ def main():
         if key in args.__dict__:
             config[key] = args.__dict__[key]
 
-    title_list = config['comma_sep_scenario_titles'].split(',')
-    scen_id = int(config['scenario_id']) - 1
-    if len(title_list) > 0 and scen_id >= 0:
-        config['scenario_title'] = title_list[scen_id]
-
-    dfs, time_step_format = load_output_data(dict(**config)) # pass a copy so config cannot be changed as side effect
+    dfs, time_step_format = load_output_data(config)
     labels = load_labels()
     figures = make_figure(dfs, labels, time_step_format)
     data_for_plots = make_plot_dfs(dfs, labels, time_step_format)
@@ -331,7 +277,7 @@ def main():
         return data_for_plots
     else:
         # TODO: Print all figures from different scenarios reasonably
-        figures_to_html(figures[0], labels, config['scenario_title'], config['first_time_step'], filename=config['output_html_file'])
+        figures_to_html(figures[0], filename=config['output_html_file'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a potential solution to our slider issues
 Instead of using the built in sliders that come with plotly figures I made a custom slider for each figure and a callback 

Pros: 
-This solution allows the default view of charts to be a forward range selection
-This solution allows us to have a custom default selection

Cons: 
-We lose the flexibility of controlling available plots through the labels.json (because a custom callback needs to be made for every potential plot)
-May not be able to integrate with the static html output   